### PR TITLE
JAN-734-main-call-from-package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,0 @@
-'use strict';
-
-const { EventParser } = require('./lib');
-
-module.exports = EventParser;

--- a/lib/event-parser.js
+++ b/lib/event-parser.js
@@ -4,6 +4,8 @@ const EventParserError = require('./event-parser-error');
 
 const ModelEvent = require('./model-event');
 
+const modelEvent = new ModelEvent();
+
 class EventParser {
 	/**
 	 * Get the event actions
@@ -21,7 +23,6 @@ class EventParser {
 		if(!entity || !event)
 			throw new EventParserError('Message entity and event are required', EventParserError.codes.INVALID_DATA);
 
-		const modelEvent = new ModelEvent();
 		const { subscribers } = await modelEvent.getEvent(client, entity, event);
 
 		return subscribers && Array.isArray(subscribers) ? subscribers : [];

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,0 @@
-'use strict';
-
-const EventParser = require('./event-parser');
-const ModelEvent = require('./model-event');
-
-module.exports = {
-	EventParser,
-	ModelEvent
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -829,9 +829,9 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.0.tgz",
-      "integrity": "sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "@janiscommerce/event-parser",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "lib/event-parser.js",
   "scripts": {
     "test": "export TEST_ENV=true; mocha --exit -R nyan --recursive tests/",
     "test-ci": "nyc --reporter=html --reporter=text mocha --recursive tests/",
     "watch-test": "export TEST_ENV=true; mocha --exit -R nyan -w --recursive tests/",
     "coverage": "nyc npm test",
-    "lint": "eslint index.js lib/ tests/"
+    "lint": "eslint lib/ tests/"
   },
   "repository": {
     "type": "git",

--- a/tests/event-parser-test.js
+++ b/tests/event-parser-test.js
@@ -4,9 +4,9 @@ const assert = require('assert');
 
 const sandbox = require('sinon').createSandbox();
 
-const Package = require('../index');
+const EventParser = require('../lib/event-parser');
 
-const { EventParser, ModelEvent } = require('../lib');
+const ModelEvent = require('../lib/model-event');
 
 describe('EventParser', () => {
 	const message = {
@@ -24,10 +24,6 @@ describe('EventParser', () => {
 
 	afterEach(() => {
 		sandbox.restore();
-	});
-
-	it('Should return and instance of event parser', () => {
-		assert.deepStrictEqual(Package, EventParser);
 	});
 
 	it('Should throw error when not receive message', async () => {

--- a/tests/model-event-test.js
+++ b/tests/model-event-test.js
@@ -6,7 +6,7 @@ const Settings = require('@janiscommerce/settings');
 
 const sandbox = require('sinon').createSandbox();
 
-const { ModelEvent } = require('../lib');
+const ModelEvent = require('../lib/model-event');
 
 const modelEvent = new ModelEvent();
 


### PR DESCRIPTION
LINK AL TICKET
https://fizzmod.atlassian.net/browse/JAN-734

DESCRIPCIÓN DEL REQUERIMIENTO
Se propone hacer el request del archivo principal desde el main del package.json en lugar de hacerlo a través del index y mediante distintos requires

DESCRIPCIÓN DE LA SOLUCIÓN
1. Se cambio la ruta del main en el package.json a /lib/event-parser.js
2. Se modificaron los test para que sean compatibles con este cambio
3. Se movio la instancia del modelo a la parte superior por un tema de performance en SLS
4. Se elimino la vulnerabilidad del eslint utils